### PR TITLE
Resolve errors on outdated Dockerfile, runs local

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:xenial
-MAINTAINER Seppe vanden Broucke <seppe.vandenbroucke@kuleuven.be>
+#MAINTAINER Seppe vanden Broucke <seppe.vandenbroucke@kuleuven.be>
 
 RUN apt update -y \
     && apt install -y apt-transport-https ca-certificates curl software-properties-common \
@@ -15,7 +15,10 @@ RUN { \
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
 RUN add-apt-repository "deb https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse"
-RUN apt update -y && apt install -y mongodb-org
+RUN apt update -y
+## Set mongodb and dependecies to version 3.6.2
+#  The latest 3.6.23 failed for me
+RUN apt install -y mongodb-org=3.6.2 mongodb-org-server=3.6.2 mongodb-org-shell=3.6.2 mongodb-org-mongos=3.6.2 mongodb-org-tools=3.6.2
 RUN mkdir -p /data/db
 
 ADD entrypoint.sh /entrypoint.sh
@@ -36,4 +39,9 @@ RUN sed -i 's/define("STANDALONE", false);/define("STANDALONE", true);/g' /var/w
 ENV JAVA_HOME /usr
 EXPOSE 80
 
+## To solve the following error:
+#  standard_init_linux.go:228: exec user process caused: no such file or directory
+#  https://stackoverflow.com/questions/68881023/docker-standard-init-linux-go228-exec-user-process-caused-no-such-file-or-dir
+RUN apt install dos2unix
+RUN dos2unix /entrypoint.sh
 CMD ["/entrypoint.sh"]


### PR DESCRIPTION
I noticed docker-machine command is deprecated.

I run the container locally and access through localhost in stead of through a Virtual Machine.

The changes to the Dockerfile solved the errors I was receiving when running the container.